### PR TITLE
fix: props type

### DIFF
--- a/dom.d.ts
+++ b/dom.d.ts
@@ -11,7 +11,7 @@ export interface KnownProps {
   attributes?: StringableRecord
 }
 
-export type Props = KnownProps & StringableRecord
+export type Props = KnownProps | StringableRecord
 
 export type Child = Nil | Node | Stringable | Child[]
 


### PR DESCRIPTION
Actually it's bug, but TS cannot catch that. At the moment our
`Stringable` type works as `any` because all types have `toString`
from `Object`.

I think we also should change `Stringable` to `any`, because it's true,
but I think making an allowlist would be better.